### PR TITLE
debugger: fix debugger failure when passing commands with non-latin symbols

### DIFF
--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 
 const assert = require('assert');
 const net = require('net');
@@ -150,12 +150,17 @@ Client.prototype._transform = function _transform(data, enc, cb) {
         return this.destroy('Expected content-length');
 
       len = len | 0;
-      if (Buffer.byteLength(this.buffer) < len)
+      var bufLength = Buffer.byteLength(this.buffer, 'utf8');
+      if (bufLength < len)
         break;
 
-      this.push(new Command(this.headers, this.buffer.slice(0, len)));
+      var buf = Buffer.allocUnsafe(bufLength);
+      buf.write(this.buffer, 0, bufLength, 'utf8');
+      var body = buf.slice(0, len).toString('utf8');
+
+      this.push(new Command(this.headers, body));
       this.state = 'headers';
-      this.buffer = this.buffer.slice(len);
+      this.buffer = buf.slice(len).toString('utf8');
       this.headers = {};
     }
   }

--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -100,7 +100,7 @@ function Client(agent, socket) {
   // Parse incoming data
   this.state = 'headers';
   this.headers = {};
-  this.buffer = '';
+  this.buffer = new Buffer(0);
   socket.pipe(this);
 
   this.on('data', this.onCommand);
@@ -121,7 +121,7 @@ Client.prototype.destroy = function destroy(msg) {
 Client.prototype._transform = function _transform(data, enc, cb) {
   cb();
 
-  this.buffer += data;
+  this.buffer = Buffer.concat([this.buffer, data]);
 
   while (true) {
     if (this.state === 'headers') {
@@ -129,7 +129,8 @@ Client.prototype._transform = function _transform(data, enc, cb) {
       if (!this.buffer.includes('\r\n'))
         break;
 
-      if (this.buffer.startsWith('\r\n')) {
+      var bufString = this.buffer.toString('utf8');
+      if (bufString.startsWith('\r\n')) {
         this.buffer = this.buffer.slice(2);
         this.state = 'body';
         continue;
@@ -137,30 +138,25 @@ Client.prototype._transform = function _transform(data, enc, cb) {
 
       // Match:
       //   Header-name: header-value\r\n
-      var match = this.buffer.match(/^([^:\s\r\n]+)\s*:\s*([^\s\r\n]+)\r\n/);
+      var match = bufString.match(/^([^:\s\r\n]+)\s*:\s*([^\s\r\n]+)\r\n/);
       if (!match)
         return this.destroy('Expected header, but failed to parse it');
 
       this.headers[match[1].toLowerCase()] = match[2];
 
-      this.buffer = this.buffer.slice(match[0].length);
+      this.buffer = this.buffer.slice(Buffer.byteLength(match[0], 'utf8'));
     } else {
       var len = this.headers['content-length'];
       if (len === undefined)
         return this.destroy('Expected content-length');
 
       len = len | 0;
-      var bufLength = Buffer.byteLength(this.buffer, 'utf8');
-      if (bufLength < len)
+      if (Buffer.byteLength(this.buffer, 'utf8') < len)
         break;
 
-      var buf = Buffer.allocUnsafe(bufLength);
-      buf.write(this.buffer, 0, bufLength, 'utf8');
-      var body = buf.slice(0, len).toString('utf8');
-
-      this.push(new Command(this.headers, body));
+      this.push(new Command(this.headers, this.buffer.slice(0, len).toString('utf8')));
       this.state = 'headers';
-      this.buffer = buf.slice(len).toString('utf8');
+      this.buffer = this.buffer.slice(len);
       this.headers = {};
     }
   }

--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -100,7 +100,7 @@ function Client(agent, socket) {
   // Parse incoming data
   this.state = 'headers';
   this.headers = {};
-  this.buffer = new Buffer(0);
+  this.buffer = Buffer.alloc(0);
   socket.pipe(this);
 
   this.on('data', this.onCommand);
@@ -154,7 +154,8 @@ Client.prototype._transform = function _transform(data, enc, cb) {
       if (Buffer.byteLength(this.buffer, 'utf8') < len)
         break;
 
-      this.push(new Command(this.headers, this.buffer.slice(0, len).toString('utf8')));
+      this.push(new Command(this.headers, 
+        this.buffer.slice(0, len).toString('utf8')));
       this.state = 'headers';
       this.buffer = this.buffer.slice(len);
       this.headers = {};


### PR DESCRIPTION
Debug agent incorrectly used Content-Length and cut Content-Length symbols instead of Content-Length bytes from debugger protocol messages. This causes incorrect command body extraction and parsing that leads to debugger disconnection.

This fixes debugger problem mistakenly reported here Microsoft/vscode#17389